### PR TITLE
Adding a few more install checks

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -9,12 +9,32 @@ $url             = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.4.0_w
 $url64           = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.4.0_windows_amd64.zip'
 $fileLocation    = Join-Path $install_folder 'telegraf.exe'
 
+# Make sure the config directory exists
 If(!(Test-Path -Path $configDirectory)){
   New-Item -Path $configDirectory -ItemType Directory
 }
 
-If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
+# If telegraf.exe exists, and the service is running, stop the service
+If (Test-Path -Path $fileLocation){
+  If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
+    Stop-Service -Name "telegraf"
+    Start-Sleep -s 10
+  }
+}
+
+# If telegraf.exe exists, and the service is enabled, uninstall the service
+If (Test-Path -Path $fileLocation){
+  If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
     & $fileLocation --service uninstall
+  }
+}
+
+# if the service is already defined, do not install the service
+# otherwise install the service.
+If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
+  $installArgs = ""
+} Else {
+  $installArgs = "--service install"
 }
 
 $packageArgs = @{
@@ -33,7 +53,7 @@ $packageArgs = @{
   checksum64     = 'F23501F430C6BEB957266CC7E331FE3F45BC9BF0311176C6646C8E01B900D9DB'
   checksumType64 = 'sha256'
 
-  silentArgs     = "--config-directory `"$configDirectory`" --service install"
+  silentArgs     = "--config-directory `"$configDirectory`" $installArgs"
   validExitCodes= @(0)
 }
 


### PR DESCRIPTION
We recently tried to upgrade from telegraf 1.3.2 to 1.3.5 and it did not go
well. Our configuration management tool, chef, was doing a `choco install
telegraf -v 1.3.5` rather than a `choco upgrade telegraf`, so the telegraf
service was never stopped, which caused the install to fail because windows
wouldn't allow the telegraf.exe binary to be overwritten since it was still
running.

This adds a few checks to the chocolateyinstall script to make sure that
the service is stopped, and to make sure that the service isn't already
"installed" before passing the "--service install" flag.

It also adds some checks to make sure the binary is actually present. We've
run into a situation where chocolatey has actually removed the binary, but
the service has not been removed, so trying to uninstall the service via
the telegraf.exe binary causes the package install to error out.