### PR TITLE
Remove telegraf registry key

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -9,6 +9,7 @@ $toolsDir        = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url             = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.5.1_windows_i386.zip'
 $url64           = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.5.1_windows_amd64.zip'
 $fileLocation    = Join-Path $install_folder 'telegraf.exe'
+$telegrafRegPath = "HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\telegraf"
 
 If(!(Test-Path -Path $configDirectory)){
   New-Item -Path $configDirectory -ItemType Directory
@@ -16,6 +17,10 @@ If(!(Test-Path -Path $configDirectory)){
 
 If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
     & $fileLocation --service uninstall
+}
+
+If (Test-Path $telegrafRegPath) {
+    Remove-Item $telegrafRegPath -Force
 }
 
 $packageArgs = @{


### PR DESCRIPTION
When the telegraf service is installed using `telegraf.exe --service install` it creates a registry key at path: `HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\telegraf`. When the telegraf service is uninstall via `telegraf.exe --service uninstall` it properly removes this registry key. The issue occurs if the service is uninstalled using another method such as `sc delete telegraf`. 

This situation might happen during a botched upgrade or reinstall where the service does not get properly uninstalled before upgrade and you need to uninstall it manually. 

Reproduction:
1. Install telegraf using Chocolatey package
2. Verify service is installed
3. Remove the service using `sc delete telegraf`
4. Uninstall telegraf package using Chocolatey or delete package
5. Attempt to install package again using Chocolatey and you'll receive an error like this: 

>2019-12-27T20:39:37Z E! Failed to install Telegraf Data Collector Service: InstallAsEventCreate() failed: SYSTEM\CurrentControlSet\Services\EventLog\Application\telegraf registry key already exists

One solution seems to be just check for that key and delete it before installing telegraf.