### PR TITLE
Backup the config if it exists

### DIFF
--- a/tools/chocolateybeforemodify.ps1
+++ b/tools/chocolateybeforemodify.ps1
@@ -1,7 +1,3 @@
 If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
     Stop-Service -Name "telegraf"
 }
-
-If (Test-Path "$env:ProgramFiles\telegraf\telegraf.conf" -ErrorAction SilentlyContinue) {
-    Copy-Item -Force -Path "$env:ProgramFiles\telegraf\telegraf.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.backup.conf"
-}

--- a/tools/chocolateybeforemodify.ps1
+++ b/tools/chocolateybeforemodify.ps1
@@ -3,5 +3,5 @@ If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
 }
 
 If (Test-Path "$env:ProgramFiles\telegraf\telegraf.conf" -ErrorAction SilentlyContinue) {
-    Copy-Item "$env:ProgramFiles\telegraf\telegraf.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.backup.conf"
+    Copy-Item -Force -Path "$env:ProgramFiles\telegraf\telegraf.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.backup.conf"
 }

--- a/tools/chocolateybeforemodify.ps1
+++ b/tools/chocolateybeforemodify.ps1
@@ -1,3 +1,7 @@
 If (Get-Service -Name "telegraf" -ErrorAction SilentlyContinue) {
     Stop-Service -Name "telegraf"
 }
+
+If (Test-Path "$env:ProgramFiles\telegraf\telegraf.conf" -ErrorAction SilentlyContinue) {
+    Copy-Item "$env:ProgramFiles\telegraf\telegraf.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.backup.conf"
+}

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -47,5 +47,5 @@ Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyInstallPackage @packageArgs
 
 If (Test-Path "$env:ProgramFiles\telegraf\telegraf.backup.conf" -ErrorAction SilentlyContinue) {
-  Copy-Item "$env:ProgramFiles\telegraf\telegraf.backup.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.conf"
+  Move-Item -Force -Path "$env:ProgramFiles\telegraf\telegraf.backup.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.conf"
 }

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -23,6 +23,10 @@ If (Test-Path $telegrafRegPath) {
     Remove-Item $telegrafRegPath -Force
 }
 
+If (Test-Path "$env:ProgramFiles\telegraf\telegraf.conf" -ErrorAction SilentlyContinue) {
+  Copy-Item -Force -Path "$env:ProgramFiles\telegraf\telegraf.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.backup.conf"
+}
+
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $unzip_folder
@@ -44,9 +48,10 @@ $packageArgs = @{
 }
 
 Install-ChocolateyZipPackage @packageArgs
+Install-ChocolateyInstallPackage @packageArgs
 
 If (Test-Path "$env:ProgramFiles\telegraf\telegraf.backup.conf" -ErrorAction SilentlyContinue) {
   Move-Item -Force -Path "$env:ProgramFiles\telegraf\telegraf.backup.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.conf"
+  Restart-Service -Name "telegraf"
 }
 
-Install-ChocolateyInstallPackage @packageArgs

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -44,8 +44,9 @@ $packageArgs = @{
 }
 
 Install-ChocolateyZipPackage @packageArgs
-Install-ChocolateyInstallPackage @packageArgs
 
 If (Test-Path "$env:ProgramFiles\telegraf\telegraf.backup.conf" -ErrorAction SilentlyContinue) {
   Move-Item -Force -Path "$env:ProgramFiles\telegraf\telegraf.backup.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.conf"
 }
+
+Install-ChocolateyInstallPackage @packageArgs

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+$ErrorActionPreference = 'Stop';
 
 $unzip_folder    = $env:ProgramFiles
 $install_folder  = "$unzip_folder\telegraf"
@@ -45,3 +45,7 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage @packageArgs
 Install-ChocolateyInstallPackage @packageArgs
+
+If (Test-Path "$env:ProgramFiles\telegraf\telegraf.backup.conf" -ErrorAction SilentlyContinue) {
+  Copy-Item "$env:ProgramFiles\telegraf\telegraf.backup.conf" -Destination "$env:ProgramFiles\telegraf\telegraf.conf"
+}


### PR DESCRIPTION
With every update of the telegraf package it overwrites the config file, which is very useful because it has to be rebuilt every time. To prevent this i have added an option that saves the config file before the upgrade and plays it back after unpacking telegraf.